### PR TITLE
If zshrc file exists, dont clobber it

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,7 @@ node['oh_my_zsh']['users'].each do |user_hash|
     source "zshrc.erb"
     owner user_hash[:login]
     mode "644"
+    action :create_if_missing
     variables({
       :user => user_hash[:login],
       :theme => user_hash[:theme] || 'robbyrussell',


### PR DESCRIPTION
Thanks for putting together this chef cookcook.

The recipe currently writes a new zshrc file to the users home directory **every run**.

It would be nice if this file was only created if the user didn't already have a zshrc there.   My dotfiles source one so I don't want it clobbered every run.

This change prevents the clobbering.
