### PR TITLE
add platform-specific "profile" handling

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,10 +37,11 @@ node['oh_my_zsh']['users'].each do |user_hash|
     shell '/bin/zsh'
   end
 
-
-  execute "source /etc/profile to all zshrc" do
-    command "echo 'source /etc/profile' >> /etc/zsh/zprofile"
-    not_if "grep 'source /etc/profile' /etc/zsh/zprofile"
+  if platform?("debian", "ubuntu")
+    execute "source /etc/profile to all zshrc" do
+      command "echo 'source /etc/profile' >> /etc/zsh/zprofile"
+      not_if "grep 'source /etc/profile' /etc/zsh/zprofile"
+    end
   end
 
 end

--- a/templates/default/zshrc.erb
+++ b/templates/default/zshrc.erb
@@ -1,5 +1,8 @@
+<% case node[:platform] %>
+<% when "debian","ubuntu" %>
 source $HOME/.profile
 
+<% end %>
 # Path to your oh-my-zsh configuration.
 ZSH=$HOME/.oh-my-zsh
 


### PR DESCRIPTION
- only on 'ubuntu' or 'debian', add 'source /etc/profile' to /etc/zsh/zprofile.
- ".profile" does not exists on rhel-clone as default, so skip it on template.
